### PR TITLE
[Qwen Code] FIX: убрать квадраты с фоном под иконками в дашборде

### DIFF
--- a/web/static/src/views/DashboardView.vue
+++ b/web/static/src/views/DashboardView.vue
@@ -6,7 +6,7 @@
       <div class="grid grid-cols-1 md:grid-cols-3 gap-4 lg:gap-6">
         <div class="bg-white rounded shadow p-4 lg:p-6">
           <div class="flex items-center gap-4">
-            <div class="w-12 h-12 rounded bg-teal-100 flex items-center justify-center text-2xl">
+            <div class="w-12 h-12 flex items-center justify-center text-3xl">
               📅
             </div>
             <div>
@@ -18,7 +18,7 @@
 
         <div class="bg-white rounded shadow p-4 lg:p-6">
           <div class="flex items-center gap-4">
-            <div class="w-12 h-12 rounded bg-blue-100 flex items-center justify-center text-2xl">
+            <div class="w-12 h-12 flex items-center justify-center text-3xl">
               📊
             </div>
             <div>
@@ -30,7 +30,7 @@
 
         <div class="bg-white rounded shadow p-4 lg:p-6">
           <div class="flex items-center gap-4">
-            <div class="w-12 h-12 rounded bg-purple-100 flex items-center justify-center text-2xl">
+            <div class="w-12 h-12 flex items-center justify-center text-3xl">
               👥
             </div>
             <div>
@@ -46,7 +46,7 @@
         <h2 class="text-lg font-semibold text-gray-900 mb-4">Быстрые действия</h2>
         <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
           <router-link to="/dashboard/schedules" class="flex items-center gap-4 p-4 rounded border border-gray-200 hover:border-teal-300 hover:bg-teal-50 transition-colors">
-            <div class="w-10 h-10 rounded bg-teal-100 flex items-center justify-center text-xl">
+            <div class="w-10 h-10 flex items-center justify-center text-2xl">
               📅
             </div>
             <div>
@@ -56,7 +56,7 @@
           </router-link>
 
           <router-link to="/dashboard/template" class="flex items-center gap-4 p-4 rounded border border-gray-200 hover:border-teal-300 hover:bg-teal-50 transition-colors">
-            <div class="w-10 h-10 rounded bg-teal-100 flex items-center justify-center text-xl">
+            <div class="w-10 h-10 flex items-center justify-center text-2xl">
               📋
             </div>
             <div>
@@ -66,7 +66,7 @@
           </router-link>
 
           <router-link to="/dashboard/users" class="flex items-center gap-4 p-4 rounded border border-gray-200 hover:border-teal-300 hover:bg-teal-50 transition-colors">
-            <div class="w-10 h-10 rounded bg-teal-100 flex items-center justify-center text-xl">
+            <div class="w-10 h-10 flex items-center justify-center text-2xl">
               👥
             </div>
             <div>
@@ -76,7 +76,7 @@
           </router-link>
 
           <router-link to="/dashboard/invites" class="flex items-center gap-4 p-4 rounded border border-gray-200 hover:border-teal-300 hover:bg-teal-50 transition-colors">
-            <div class="w-10 h-10 rounded bg-teal-100 flex items-center justify-center text-xl">
+            <div class="w-10 h-10 flex items-center justify-center text-2xl">
               🔗
             </div>
             <div>
@@ -145,7 +145,7 @@
         <h2 class="text-lg font-semibold text-gray-900 mb-4">Быстрые действия</h2>
         <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
           <router-link to="/dashboard/calendar" class="flex items-center gap-4 p-4 rounded border border-gray-200 hover:border-teal-300 hover:bg-teal-50 transition-colors">
-            <div class="w-10 h-10 rounded bg-teal-100 flex items-center justify-center text-xl">
+            <div class="w-10 h-10 flex items-center justify-center text-2xl">
               📅
             </div>
             <div>
@@ -155,7 +155,7 @@
           </router-link>
 
           <router-link to="/dashboard/my-trainings" class="flex items-center gap-4 p-4 rounded border border-gray-200 hover:border-teal-300 hover:bg-teal-50 transition-colors">
-            <div class="w-10 h-10 rounded bg-teal-100 flex items-center justify-center text-xl">
+            <div class="w-10 h-10 flex items-center justify-center text-2xl">
               📝
             </div>
             <div>


### PR DESCRIPTION
## Описание

Убраны квадраты с фоновым цветом под иконками в дашборде админа.

## Изменения

**Frontend:**
- DashboardView.vue: убраны bg-teal-100, bg-blue-100, bg-purple-100 и rounded
- Увеличен размер иконок с text-xl на text-2xl/text-3xl для лучшей видимости

## До/После

**Было:**
- Иконки с квадратным фоном (bg-teal-100 и т.д.)

**Стало:**
- Чистые иконки без фона

## Связанные issues

Closes #26