### PR TITLE
[Qwen Code] Исправление отображения сайдбара на мобильных устройствах

### DIFF
--- a/web/static/src/views/AdminLayout.vue
+++ b/web/static/src/views/AdminLayout.vue
@@ -1,9 +1,18 @@
 <template>
-  <div class="flex h-screen bg-gradient-to-br from-slate-100 to-slate-200 overflow-hidden">
+  <div class="flex min-h-screen bg-gradient-to-br from-slate-100 to-slate-200">
+    <!-- Кнопка гамбургера для мобильных -->
+    <button
+      @click="toggleMenu"
+      class="fixed top-4 left-4 z-30 lg:hidden p-2 rounded-lg bg-white shadow-md hover:bg-gray-50 transition-colors"
+      aria-label="Открыть меню"
+    >
+      <Menu class="w-6 h-6 text-gray-700" />
+    </button>
+
     <Sidebar />
 
-    <div class="flex-1 flex flex-col min-w-0 overflow-hidden">
-      <main class="flex-1 p-4 lg:p-6 overflow-y-auto">
+    <div class="flex-1 flex flex-col min-w-0">
+      <main class="flex-1 p-4 lg:p-6 pt-16 lg:pt-6 overflow-y-auto">
         <div class="max-w-7xl mx-auto">
           <RouterView />
         </div>
@@ -13,5 +22,10 @@
 </template>
 
 <script setup>
+import { Menu } from 'lucide-vue-next'
 import Sidebar from '@/components/Sidebar.vue'
+
+const toggleMenu = () => {
+  window.dispatchEvent(new CustomEvent('toggle-menu'))
+}
 </script>


### PR DESCRIPTION
Исправлена проблема с отображением сайдбара на мобильных устройствах.

## Изменения
- Убран `overflow-hidden` с корневого элемента AdminLayout.vue (из-за него fixed-позиционированный сайдбар обрезался)
- Добавлена кнопка гамбургера для открытия меню на мобильных устройствах
- Сайдбар теперь корректно отображается с fixed позиционированием
- Overlay затемняет фон при открытом меню
- Добавлен отступ сверху для контента на мобильных (`pt-16`) чтобы кнопка гамбургера не перекрывала контент

## Тестирование
- Сборка прошла успешно без ошибок
- Все чанки собраны корректно

Closes #60