### PR TITLE
[Qwen Code] Исправление навигации на мобильных и разделение прав доступа

### DIFF
--- a/web/static/src/components/Sidebar.vue
+++ b/web/static/src/components/Sidebar.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { ref, computed, onMounted, onUnmounted } from 'vue'
+import { ref, computed, onMounted, onUnmounted, watch } from 'vue'
 import { useAuthStore } from '@/stores/auth'
 import { useRouter } from 'vue-router'
 import {
@@ -16,6 +16,8 @@ import logo from '@/img/logo.svg'
 
 const authStore = useAuthStore()
 const router = useRouter()
+
+const emit = defineEmits(['menu-change'])
 
 const isOpen = ref(false)
 
@@ -38,7 +40,14 @@ const handleLogout = async () => {
 
 const handleToggleMenu = () => {
   isOpen.value = !isOpen.value
+  // Блокируем прокрутку body при открытом меню
+  document.body.style.overflow = isOpen.value ? 'hidden' : ''
 }
+
+// Отправляем состояние меню родителю
+watch(isOpen, (newValue) => {
+  emit('menu-change', newValue)
+})
 
 onMounted(() => {
   window.addEventListener('toggle-menu', handleToggleMenu)
@@ -46,6 +55,8 @@ onMounted(() => {
 
 onUnmounted(() => {
   window.removeEventListener('toggle-menu', handleToggleMenu)
+  // Сбрасываем блокировку прокрутки
+  document.body.style.overflow = ''
 })
 </script>
 
@@ -60,7 +71,7 @@ onUnmounted(() => {
   <!-- Sidebar -->
   <aside
     :class="[
-      'fixed lg:static inset-y-0 left-0 z-50 w-64 bg-white border-r border-gray-200 flex flex-col transform transition-transform duration-300 lg:transform-none',
+      'fixed lg:relative inset-y-0 left-0 z-50 w-64 bg-white border-r border-gray-200 flex flex-col transform transition-transform duration-300 lg:transform-none lg:h-full',
       isOpen ? 'translate-x-0' : '-translate-x-full lg:translate-x-0'
     ]"
   >

--- a/web/static/src/router/index.js
+++ b/web/static/src/router/index.js
@@ -17,7 +17,8 @@ const router = createRouter({
         {
           path: '',
           name: 'dashboard',
-          component: () => import('@/views/DashboardView.vue')
+          component: () => import('@/views/DashboardView.vue'),
+          meta: { requiresAdmin: true }
         },
         {
           path: 'calendar',
@@ -32,33 +33,38 @@ const router = createRouter({
         {
           path: 'template',
           name: 'template',
-          component: () => import('@/views/TemplateView.vue')
+          component: () => import('@/views/TemplateView.vue'),
+          meta: { requiresAdmin: true }
         },
         {
           path: 'schedules',
           name: 'schedules',
-          component: () => import('@/views/SchedulesView.vue')
+          component: () => import('@/views/SchedulesView.vue'),
+          meta: { requiresAdmin: true }
         },
         {
           path: 'users',
           name: 'users',
-          component: () => import('@/views/AdminsView.vue')
+          component: () => import('@/views/AdminsView.vue'),
+          meta: { requiresAdmin: true }
         },
         {
           path: 'invites',
           name: 'invites',
-          component: () => import('@/views/InviteView.vue')
+          component: () => import('@/views/InviteView.vue'),
+          meta: { requiresAdmin: true }
         },
         {
           path: 'trainings',
           name: 'trainings',
-          component: () => import('@/views/TrainingsView.vue')
+          component: () => import('@/views/TrainingsView.vue'),
+          meta: { requiresAdmin: true }
         }
       ]
     },
     {
       path: '/user',
-      redirect: '/dashboard'
+      redirect: '/dashboard/calendar'
     },
     {
       path: '/admin',
@@ -83,6 +89,12 @@ router.beforeEach(async (to, from, next) => {
 
     if (!authStore.isAuthenticated) {
       return next('/')
+    }
+
+    // Проверка прав администратора для защищенных маршрутов
+    if (to.meta.requiresAdmin && !authStore.isAdmin) {
+      // Обычные пользователи перенаправляются на календарь
+      return next('/dashboard/calendar')
     }
   }
 

--- a/web/static/src/views/AdminLayout.vue
+++ b/web/static/src/views/AdminLayout.vue
@@ -1,19 +1,23 @@
 <template>
-  <div class="flex min-h-screen bg-gradient-to-br from-slate-100 to-slate-200">
-    <!-- Кнопка гамбургера для мобильных -->
+  <div class="flex h-screen bg-gradient-to-br from-slate-100 to-slate-200">
+    <!-- Сайдбар с h-full, чтобы занимал всю высоту -->
+    <div class="flex-shrink-0">
+      <Sidebar @menu-change="isMenuOpen = $event" />
+    </div>
+
+    <!-- Кнопка гамбургера для мобильных (скрывается при открытом меню) -->
     <button
+      v-show="!isMenuOpen"
       @click="toggleMenu"
-      class="fixed top-4 left-4 z-30 lg:hidden p-2 rounded-lg bg-white shadow-md hover:bg-gray-50 transition-colors"
+      class="fixed top-4 left-4 z-[60] lg:hidden p-2 rounded bg-white shadow hover:bg-gray-100 transition-colors"
       aria-label="Открыть меню"
     >
       <Menu class="w-6 h-6 text-gray-700" />
     </button>
 
-    <Sidebar />
-
-    <div class="flex-1 flex flex-col min-w-0">
-      <main class="flex-1 p-4 lg:p-6 pt-16 lg:pt-6 overflow-y-auto">
-        <div class="max-w-7xl mx-auto">
+    <div class="flex-1 flex flex-col min-w-0 overflow-hidden">
+      <main class="flex-1 overflow-y-auto p-4 lg:p-6 pt-16 lg:pt-6">
+        <div class="max-w-7xl mx-auto w-full">
           <RouterView />
         </div>
       </main>
@@ -22,10 +26,14 @@
 </template>
 
 <script setup>
+import { ref } from 'vue'
 import { Menu } from 'lucide-vue-next'
 import Sidebar from '@/components/Sidebar.vue'
 
+const isMenuOpen = ref(false)
+
 const toggleMenu = () => {
+  isMenuOpen.value = !isMenuOpen.value
   window.dispatchEvent(new CustomEvent('toggle-menu'))
 }
 </script>


### PR DESCRIPTION
## Изменения

Исправлена проблема с отображением меню на мобильных устройствах (Issue #60).

### Что исправлено:

**Роутер:**
- Добавлена защита админских маршрутов через meta.requiresAdmin
- Обычные пользователи автоматически перенаправляются на Календарь
- Редирект /user изменен на /dashboard/calendar

**AdminLayout.vue:**
- Сайдбар вынесен из контейнера с overflow-hidden
- Кнопка гамбургера скрывается при открытом меню
- Кнопка имеет белый фон и тень

**Sidebar.vue:**
- Блокировка прокрутки body при открытом меню
- Отправка события menu-change родителю

### Разделение прав:
- **Администраторы:** видят все пункты меню
- **Обычные пользователи:** видят только Календарь и Мои тренировки

### Проверка:
- Сборка: npm run build ✅
- Мобильная версия: гамбургер работает, overlay затемняет фон
- Права доступа: обычные пользователи не попадают на админские страницы

Closes #60