### PR TITLE
[Qwen Code] FIX #41: Блокировка доступа деактивированным пользователям

### DIFF
--- a/web/app.py
+++ b/web/app.py
@@ -212,7 +212,14 @@ async def get_current_user_from_access_cookie(request: Request) -> dict:
             status_code=status.HTTP_404_UNAUTHORIZED,
             detail="Пользователь не найден",
         )
-    
+
+    # Проверяем, что пользователь активен
+    if not user.get('is_active', True):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Пользователь деактивирован",
+        )
+
     return user
 
 


### PR DESCRIPTION
## Изменения

Добавлена проверка статуса `is_active` пользователя при каждом запросе к API.

## Что исправлено

- В функцию `get_current_user_from_access_cookie()` добавлена проверка `is_active`
- Деактивированные пользователи получают **403 Forbidden** при любом запросе к API
- Сессия больше не работает после деактивации пользователя

## Тестирование

- ✅ Сервер перезапущен без ошибок
- ✅ Синтаксис кода проверен
- ✅ Логирование в норме

Closes #41